### PR TITLE
connman_ncurses crashes when toggling between online/offline modes

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -912,7 +912,7 @@ static void react_to_sig_manager(struct json_object *interface,
 					0));
 		json_object_object_del(state, tmp_str);
 		json_object_object_add(state, tmp_str,
-				json_object_array_get_idx(data, 1));
+				json_object_get(json_object_array_get_idx(data, 1)));
 
 	} else if (strcmp(sig_name, key_sig_tech_added) == 0) {
 		json_object_array_add(technologies, json_object_get(data));


### PR DESCRIPTION
Testcase:
1. Execute connman_ncurses
2. Press 'o' on an available technology (tested only for wifi)
3. The status is toggle, the network is shutdown or configured but connman_ncurses crashes.

libjson-c2 version 0.11-3. I don't know enough  C, but anyway went on and tried to debug by myself without success =)

``` gdb
(gdb) bt
#0  0x00007ffff77752b0 in printbuf_reset () from /lib/x86_64-linux-gnu/libjson-c.so.2
#1  0x00007ffff777158e in json_object_to_json_string_ext () from /lib/x86_64-linux-gnu/libjson-c.so.2
#2  0x00000000004093b1 in __renderers_state (jobj=0x618e40) at renderers.c:237
#3  0x0000000000409534 in __renderers_home_page (jobj=0x6482d0) at renderers.c:271
#4  0x000000000040d175 in action_on_cmd_callback (jobj=0x648590) at main.c:475
#5  0x000000000040e039 in main_callback (status=0, jobj=0x648590) at main.c:831
#6  0x000000000040761d in get_home_page (jobj=0x0) at engine.c:353
#7  0x00000000004088eb in engine_query (jobj=0x647c40) at engine.c:964
#8  0x000000000040e1fe in print_home_page () at main.c:882
#9  0x000000000040cdc7 in exec_refresh () at main.c:362
#10 0x000000000040d46e in action_on_signal (jobj=0x643b10) at main.c:559
#11 0x000000000040e053 in main_callback (status=12345, jobj=0x643b10) at main.c:834
#12 0x00000000004080ff in engine_commands_sig (jobj=0x643b10) at engine.c:765
#13 0x0000000000405476 in monitor_changed (connection=0x616c30, message=0x618710, user_data=0x0) at commands.c:622
#14 0x00007ffff7ba4ad6 in dbus_connection_dispatch () from /lib/x86_64-linux-gnu/libdbus-1.so.3
#15 0x0000000000406dc9 in loop_run (poll_stdin=true) at loop.c:194
#16 0x000000000040f7ad in main () at main.c:1554
```
