### PR TITLE
connman_ncurses crashes when No suitable services are found in a technology and the user press enter

### DIFF
--- a/main.c
+++ b/main.c
@@ -1275,6 +1275,10 @@ static void exec_action_context_home(int ch)
 		case KEY_ENTER:
 		case 10:
 			item = current_item(main_menu);
+
+			if (!item) // No technologies available but the user presses Enter
+				break;
+
 			exec_action(item_userptr(item));
 			break;
 	}
@@ -1398,6 +1402,10 @@ static void exec_action_context_services(int ch)
 		case KEY_ENTER:
 		case 10:
 			item = current_item(main_menu);
+
+			if (!item) // No services available but the user presses Enter
+				break;
+
 			exec_action(item_userptr(item));
 			print_info_in_footer(false, "Connecting...");
 			break;


### PR DESCRIPTION
Hi, I've just keep playing with connman_curses and I found the following:

Testcase:
1. Press `enter` in an `ethernet interface unplugged` (this also works in a wifi interface when no AP are available. connman_curses display **No suitable services found for this technology**
2. Press `enter`. connman_curses crashes with a segmentation fault error.

The backtrace display the following:

```
0x000000000040d004 in exec_action (data=0x0) at main.c:427                                                                         │
427             context.serv->dbus_name = strdup(data->dbus_name);                                                 │
(gdb) backtrace                                                                                                                    │
#0  0x000000000040d004 in exec_action (data=0x0) at main.c:427                                                                     │
#1  0x000000000040f341 in exec_action_context_services (ch=10) at main.c:1401                                                      │
#2  0x000000000040f5eb in ncurses_action () at main.c:1499                                                                         │
#3  0x0000000000406df0 in loop_run (poll_stdin=true) at loop.c:199                                                                 │
#4  0x000000000040f7b5 in main () at main.c:1554
frame 1
#1  0x000000000040f341 in exec_action_context_services (ch=10) at main.c:1401
1401                exec_action(item_userptr(item));
(gdb) p item
$2 = (ITEM *) 0x0
```

I think the problem may be than `item` is defined as a null pointer (such term exist?) at that menu. If I edit the code as follows:

``` c
//main.c:1401
                        if (item != NULL) {
                exec_action(item_userptr(item));
                        }
```

It doesn't crash anymore but just prints a `[INFO] Connecting...` below.
