### PR TITLE
Address Sanitizer detected a memory leak in main_items

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,14 @@ AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug],
 	fi
 ])
 
+AC_ARG_ENABLE(asan, AC_HELP_STRING([--enable-asan],
+			[enable Address Sanitizer]), [
+	if (test "${enableval}" = "yes" &&
+				test "${ac_cv_prog_cc_g}" = "yes"); then
+		CFLAGS="$CFLAGS -g -fsanitize=address -fno-omit-frame-pointer"
+	fi
+])
+
 AC_CONFIG_HEADERS([config.h:config.h.in])
 
 PKG_CHECK_MODULES(JSON, [json-c],,

--- a/renderers.c
+++ b/renderers.c
@@ -507,7 +507,7 @@ static void renderers_service_config(struct json_object *serv_array)
 			json_object_array_get_idx(serv_array, 0));
 
 	longest_key_len = 25 + 4; // len("Nameservers.Configuration") + padding
-	main_fields = malloc(sizeof(ITEM *) * max_nb_fields); // 113 = #fields + #labels + 1
+	main_fields = malloc(sizeof(FIELD *) * max_nb_fields); // 113 = #fields + #labels + 1
 	i = 0;
 
 	str_field[0] = '\0';

--- a/renderers.c
+++ b/renderers.c
@@ -763,6 +763,7 @@ void __renderers_free_services(void)
 {
 	int i;
 	struct userptr_data *data;
+	const char *item_name_desc = NULL;
 
 	if (main_menu == NULL)
 		return;
@@ -774,6 +775,17 @@ void __renderers_free_services(void)
 		free((void *) data->dbus_name);
 		free((void *) data->pretty_name);
 		free(data);
+
+		item_name_desc = item_name(main_items[i]);
+
+		if (item_name_desc != NULL)
+			free((void *) item_name_desc);
+
+		item_name_desc = item_description(main_items[i]);
+
+		if (item_name_desc != NULL)
+			free((void *) item_name_desc);
+
 		free_item(main_items[i]);
 	}
 

--- a/run-me.sh
+++ b/run-me.sh
@@ -2,6 +2,6 @@
 
 autoreconf -i -f
 
-./configure --disable-optimization --enable-debug #--disable-silent-rules
+./configure --disable-optimization --enable-debug #--enable-asan --disable-silent-rules
 
 make -B


### PR DESCRIPTION
So I tried Address Sanitizer ([ASan](https://code.google.com/p/address-sanitizer/wiki/AddressSanitizer)) and it detected a memory leak in the handling of `name` and `description` of ncurses fields. I used this occasion to add an option to enable ASan in `configure`.
