### PR TITLE
Include patch from connman project

### DIFF
--- a/dbus_helpers.c
+++ b/dbus_helpers.c
@@ -49,6 +49,7 @@ static void dbus_method_reply(DBusPendingCall *call, void *user_data)
 	DBusMessageIter iter;
 
 	reply = dbus_pending_call_steal_reply(call);
+	dbus_pending_call_unref(call);
 	if (dbus_message_get_type(reply) == DBUS_MESSAGE_TYPE_ERROR) {
 		DBusError err;
 


### PR DESCRIPTION
Apparently there is a memory leak in `dbus_helpers.c` function `dbus_method_reply(...)`, see the mail with object "[PATCH 1/2] client: Memory leak on dbus reply" from Jaakko Hannikainen on the connman ML.
I will adapt the patch and do a PR for it as soon as it's accepted in connman's official git.
