### PR TITLE
lintian: no-standards-version-field

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,6 +3,7 @@ Maintainer: Javier López <m@javier.io>
 Section: net
 Priority: optional
 Build-Depends: debhelper  (>=9), libjson-c2, libjson-c-dev, autoconf (>=2.69), automake, libncurses5, libncurses5-dev, libdbus-1-dev, dh-exec (>= 0.12)
+Standards-Version: 3.9.0
 
 Package: connman-curses-git
 Architecture: any

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,7 @@ Source: connman-curses-git
 Maintainer: Javier López <m@javier.io>
 Section: net
 Priority: optional
-Build-Depends: debhelper  (>=9), libjson-c2, libjson-c-dev, autoconf (>=2.69), automake, libncurses5, libncurses5-dev, libdbus-1-dev, dh-exec (>= 0.12)
+Build-Depends: debhelper  (>=9), libjson-c-dev, autoconf (>=2.69), automake, libncurses5, libncurses5-dev, libdbus-1-dev, dh-exec (>= 0.12)
 Standards-Version: 3.9.0
 
 Package: connman-curses-git


### PR DESCRIPTION
```
[  739s] + lintian -i /usr/src/packages/connman-curses-git_999999999999+git_armhf.changes
[  753s] E: connman-curses-git source: no-standards-version-field
[  753s] N: 
[  753s] N:    The source package does not have a Standards-Version control field.
[  753s] N:    Please update your package to latest Policy and set this control field
[  753s] N:    appropriately.
[  753s] N:    
[  753s] N:    Refer to Debian Policy Manual section 5.6.11 (Standards-Version) for
[  753s] N:    details.
[  753s] N:    
[  753s] N:    Severity: important, Certainty: certain
[  753s] N:    
[  753s] N:    Check: standards-version, Type: source
[  753s] N: 
```